### PR TITLE
Rework workflows a little bit

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -6,6 +6,8 @@ name: CI
 on:
   pull_request:
     branches: [ main ]
+  push:
+    branches: [ main ]
   workflow_call:
     inputs:
       publishes:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GPIO controller for Raspberry Pi
 
-[![CI](https://github.com/2franix/rpi-controls/actions/workflows/python-package.yml/badge.svg)](https://github.com/2franix/rpi-controls/actions/workflows/python-package.yml)
-[![TestPyPI](https://github.com/2franix/rpi-controls/actions/workflows/python-publish-testpypi.yml/badge.svg)](https://github.com/2franix/rpi-controls/actions/workflows/python-publish-testpypi.yml)
+[![CI](https://github.com/2franix/rpi-controls/actions/workflows/python-package.yml/badge.svg?branch=main)](https://github.com/2franix/rpi-controls/actions/workflows/python-package.yml)
+[![TestPyPI](https://github.com/2franix/rpi-controls/actions/workflows/python-publish-testpypi.yml/badge.svg?branch=main)](https://github.com/2franix/rpi-controls/actions/workflows/python-publish-testpypi.yml)
 [![PyPI](https://github.com/2franix/rpi-controls/actions/workflows/python-publish-pypi.yml/badge.svg)](https://github.com/2franix/rpi-controls/actions/workflows/python-publish-pypi.yml)
 
 This package provides classes to interact with physical buttons connected to a Raspberry Pi's GPIO. Those classes make it easy to run event-driven callbacks.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # GPIO controller for Raspberry Pi
 
 [![CI](https://github.com/2franix/rpi-controls/actions/workflows/python-package.yml/badge.svg?branch=main)](https://github.com/2franix/rpi-controls/actions/workflows/python-package.yml)
-[![TestPyPI](https://github.com/2franix/rpi-controls/actions/workflows/python-publish-testpypi.yml/badge.svg?branch=main)](https://github.com/2franix/rpi-controls/actions/workflows/python-publish-testpypi.yml)
 [![PyPI](https://github.com/2franix/rpi-controls/actions/workflows/python-publish-pypi.yml/badge.svg)](https://github.com/2franix/rpi-controls/actions/workflows/python-publish-pypi.yml)
+[![TestPyPI](https://github.com/2franix/rpi-controls/actions/workflows/python-publish-testpypi.yml/badge.svg?branch=main)](https://github.com/2franix/rpi-controls/actions/workflows/python-publish-testpypi.yml)
 
 This package provides classes to interact with physical buttons connected to a Raspberry Pi's GPIO. Those classes make it easy to run event-driven callbacks.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ pythonVersion = "3.7"
 
 [tool.poetry]
 name = "rpi-controls"
-version = "1.0.2"
+version = "1.0.3"
 description = "Library that eases interacting with physical buttons through the Raspberry Pi GPIO"
 authors = ["Cyrille Defranoux"]
 maintainers = ["Cyrille Defranoux <cyrille.github@defx.fr>"]


### PR DESCRIPTION
Execute CI build on every changes done on main and use main for the
badge
Also use main for the TestPyPI badge